### PR TITLE
Expand the build.sh script to automate compiling the required libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,15 @@ us single bullet fire weapons.
 2. Compile `protobuf`
 
    A. `cd` into `thirdparty/protobuf-2.5.0`
+      
+   B. Run `chmod +x configure && ./configure`
    
-   B. Run `autoreconf`
+   C. Run `make -j$(nproc)`
    
-   C. Run `chmod +x configure && ./configure`
-   
-   D. Run `make -j$(nproc)`
-   
-3. `cd` back into root directory, and run  `./creategamesprojects.sh`
+3. `cd` back into root directory, and run  `./creategameprojects.sh`
 4. Run `NO_CHROOT=1 VALVE_NO_AUTO_P4=1 make -f games.mak` 
 
+Alternatively, once you have downloaded the required patches you can run the `build.sh` script to automate this process.
 
 ### Running and Debugging
 1. For the compiled binaries to run, you will need to copy your current TF2 installation to `../game` (relative to your repostiory, outside of it).

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+CORES=`nproc`
+if [ ! -f ./thirdparty/gperftools-2.0/built ]; then
+	cd ./thirdparty/gperftools-2.0 && bash ./autogen.sh && ./configure --enable-frame-pointers && make -j $CORES
+	cd ../..
+	touch ./thirdparty/gperftools-2.0/built
+fi
+
+if [ ! -f ./thirdparty/protobuf-2.5.0/built ]; then
+	cd ./thirdparty/protobuf-2.5.0 && bash ./configure && make -j $CORES
+	cd ../..
+	touch ./thirdparty/protobuf-2.5.0/built
+fi
+
+if [ ! -f ./games.mak ]; then
+	bash ./creategameprojects.sh
+fi
+
 export VALVE_NO_AUTO_P4=1
 if [[ $1 == '-v' ]]; then
   make -f games.mak NO_CHROOT=1 MAKE_JOBS=1 MAKE_VERBOSE=1 "${@:2}"


### PR DESCRIPTION
Let the build.sh script handle setting up the extra libraries, as well as running the make file.

As a note, the vpc2 version supplied in your fork cannot be used with the Steam Runtime enviroment as the glibc version is too outdated --

```devtools/bin/vpc_linux: /lib/i386-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by devtools/bin/vpc_linux)
devtools/bin/vpc_linux: /lib/i386-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by devtools/bin/vpc_linux)
devtools/bin/vpc_linux: /lib/i386-linux-gnu/libc.so.6: version `GLIBC_2.27' not found (required by devtools/bin/vpc_linux)```