### PR TITLE
Fixed undefined reference to CThreadEvent::AddListener.

### DIFF
--- a/public/tier0/threadtools.h
+++ b/public/tier0/threadtools.h
@@ -1054,7 +1054,10 @@ public:
 
 	bool Wait( uint32 dwTimeout = TT_INFINITE );
 
-	void AddListener(std::shared_ptr<std::condition_variable_any> condition);
+	void AddListener(std::shared_ptr<std::condition_variable_any> condition)
+	{
+		m_listeningConditions.PushItem(condition);
+	}
 
 private:
 	CThreadEvent( const CThreadEvent & ) = delete;

--- a/tier0/threadtools.cpp
+++ b/tier0/threadtools.cpp
@@ -673,11 +673,6 @@ bool CThreadEvent::Wait( uint32 dwTimeout )
 	return CThreadSyncObject::Wait( dwTimeout );
 }
 
-void CThreadEvent::AddListener(std::shared_ptr<std::condition_variable_any> condition)
-{
-	m_listeningConditions.PushItem(condition);
-}
-
 //-----------------------------------------------------------------------------
 //
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
./obj_vstdlib_linux32/release/jobthread.o: in function `ThreadWaitForEvents(int, CThreadEvent* const*, bool, unsigned int)':
/team-comtress-2/public/tier0/threadtools.h:1119: undefined reference to `CThreadEvent::AddListener(std::shared_ptr<std::_V2::condition_variable_any>)'

A better idea is to move ThreadWaitForEvents to threadtools.cpp, but that's more prone to merge conflicts right now.